### PR TITLE
Fixed error in middleware stack

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -27,7 +27,7 @@ class Application extends \Laravel\Lumen\Application
             // merge middleware
             $attributes['middleware'] = array_merge($lastMiddleware, $middleware);
         } else {
-            $attributes['middleware'] = end($this->middlewareStack);
+            $attributes['middleware'] = end($this->middlewareStack) ? : null;
         }
         // merge prefixes
         if (!empty($attributes['prefix'])) {


### PR DESCRIPTION
Basically there was no alternative for the end() function when the group's middleware is empty, that caused some routes to be invalid.

Adding this null alternative like in the other types of group attributes seemed to fix it.
