### PR TITLE
Nested namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "fremail/lumen-nested-route-groups",
   "type": "library",
-  "version": "1.0.1-beta",
+  "version": "1.0.2-beta",
   "description": "Extends a lumen application for using nested route groups",
   "keywords": ["lumen", "route", "group"],
   "license": "MIT",

--- a/config/NestedRouteGroups.php
+++ b/config/NestedRouteGroups.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Merging namespaces
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify if you want to use nested namespaces as in Laravel
+    |  ('nested' - it's by default) or full namespaces ('full') as Lumen 
+    |  documentation defines.
+    | See https://github.com/fremail/lumen-nested-route-groups/pull/3
+    |
+    */
+    'namespace' => 'nested',
+];

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,15 @@ $app = new Fremail\NestedRouteGroups\Application(
 ### After these simple steps you can use nested route groups in your application!
 
 
+### Additional namespaces configuration
+By default this lib uses nested namespace ([Laravel style](https://laravel.com/docs/5.2/routing#route-group-namespaces)), but you can determine to use full namespaces instead ([Lumen style](https://lumen.laravel.com/docs/5.2/routing#route-group-namespaces)).
+
+**Steps for using full namespaces:**
+1. Create `config` directory if you don't have one in the project root.
+2. Copy `NestedRouteGroups.php` from `vendor/fremail/lumen-nested-route-groups/config` folder to the created `config` dir in the root.
+3. Open the `config/NestedRouteGroups.php` file and set 'namespace' value to 'full'.
+4. Add this line to your bootstrap/app.php: `$app->configure('NestedRouteGroups');`
+
 ## Example of using this lib
 This is an example of app/Http/routes.php
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -39,16 +39,6 @@ class Application extends \Laravel\Lumen\Application
         } else {
             $attributes['prefix'] = end($this->prefixesStack) ? : null;
         }
-        // merge namespace
-        if (!empty($attributes['namespace'])) {
-            if (count($this->namespaceStack)) {
-                $attributes['namespace'] = end($this->namespaceStack) . '\\' . trim($attributes['namespace'], '\\');
-            } else {
-                $attributes['namespace'] = trim($attributes['namespace'], '\\');
-            }
-        } else {
-            $attributes['namespace'] = end($this->namespaceStack) ? : null;
-        }
 
         // merge attributes
         $this->groupAttributes = isset($this->groupAttributes) ? array_merge($this->groupAttributes, $attributes) : $attributes;

--- a/src/Application.php
+++ b/src/Application.php
@@ -39,6 +39,19 @@ class Application extends \Laravel\Lumen\Application
         } else {
             $attributes['prefix'] = end($this->prefixesStack) ? : null;
         }
+        
+        if (config('NestedRouteGroups.namespace', 'nested') === 'nested') {
+            // merge namespace
+            if (!empty($attributes['namespace'])) {
+                if (count($this->namespaceStack)) {
+                    $attributes['namespace'] = end($this->namespaceStack) . '\\' . trim($attributes['namespace'], '\\');
+                } else {
+                    $attributes['namespace'] = trim($attributes['namespace'], '\\');
+                }
+            } else {
+                $attributes['namespace'] = end($this->namespaceStack) ?: null;
+            }
+        }
 
         // merge attributes
         $this->groupAttributes = isset($this->groupAttributes) ? array_merge($this->groupAttributes, $attributes) : $attributes;


### PR DESCRIPTION
Regarding to pull request #3 I added NestedRouteGroups.namespace config property where you may determine using nested namespaces or full ones.
By default it uses nested namespaces, so updating the lib for old users won't break their projects.
See `Additional namespaces configuration` in readme.
